### PR TITLE
39 feat 멋사 1-8주차 과제

### DIFF
--- a/week08/src/Greeting.jsx
+++ b/week08/src/Greeting.jsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useState } from "react";
 
+//Access Token을 사용하여 사용자 정보를 요청하는 단계입니다.
 const Greeting = () => {
+  //이름과 프로필 이미지를 상태값으로 하여 useState로 관리합니다.
   const [name, setName] = useState();
   const [profileImg, setProfileImg] = useState();
 
   useEffect(() => {
+    //로컬 스토리지에서 access token을 가져옵니다.
     const accessToken = localStorage.getItem("accessToken");
+
+    //가져온 토큰으로 카카오 사용자 정보 api에서 사용자 정보를 요청합니다.
     fetch("https://kapi.kakao.com/v2/user/me", {
       method: "GET",
       headers: {
@@ -13,10 +18,12 @@ const Greeting = () => {
         "Content-type": "application/x-www-form-urlencoded",
       },
     }).then((res) => {
+      //요청에 대한 응답처리 부분
       const userData = res.json();
+      //응답을 json 객체로 변환합니다.
       userData.then((user) => {
-        setName(user.properties.nickname);
-        setProfileImg(user.properties.profile_image);
+        setName(user.properties.nickname); //이름 설정
+        setProfileImg(user.properties.profile_image); //프로필 이미지 설정
       });
     });
   }, []);

--- a/week08/src/Login.jsx
+++ b/week08/src/Login.jsx
@@ -3,13 +3,17 @@ import KakaoImg from "./assets/kakao_login.png";
 import GoogleImg from "./assets/google_login.png";
 
 const Login = () => {
+  //Authorization code를 발급받는 단계입니다.
+  //카카오 인증 서버로 이동하도록 합니다.
   const authServerLink = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}`;
+  //카카오 인증 서버를 호출하면서 response_type, client_id, redirect_uri 3가지 쿼리 파라미터를 같이 보냅니다.
 
   const handleKakao = () => {
     window.location.href = authServerLink;
   };
+  //위에서 만든 URL로 이동할 수 있게 하는 함수입니다.
 
   return (
     <div className="login-box">

--- a/week08/src/Redirection.jsx
+++ b/week08/src/Redirection.jsx
@@ -2,29 +2,34 @@ import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 const Redirection = () => {
+  //Authorization code로 토큰을 발급받는 단계입니다.
+
   const [params] = useSearchParams();
 
   const authCode = params.get("code");
   const grant_type = "authorization_code";
   const navigate = useNavigate();
+  //Authorization code를 추출합니다.
 
   useEffect(() => {
+    //REST_API_KEY, REDIRECT_URI, Authorization code값을 쿼리파라미터에 실어서 access token을 요청합니다.
     fetch(
       `https://kauth.kakao.com/oauth/token?grant_type=${grant_type}&client_id=${
         import.meta.env.VITE_REST_API_KEY
       }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&code=${authCode}`,
       {
-        method: "POST",
+        method: "POST", //POST 방식으로 요청
 
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": "application/x-www-form-urlencoded", //URL 인코딩 형식으로 전송
         },
       }
     ).then((res) => {
+      //요청에 대한 응답 처리 부분
       const data = res.json();
       data.then((data) => {
-        localStorage.setItem("accessToken", data.access_token);
-        navigate("/greeting");
+        localStorage.setItem("accessToken", data.access_token); //로컬스토리지에 access token을 저장합니다.
+        navigate("/greeting"); //토큰 저장 후 greeting 페이지로 이동합니다.
       });
     });
   }, [authCode, grant_type, navigate]);

--- a/week08/src/Redirection.jsx
+++ b/week08/src/Redirection.jsx
@@ -26,7 +26,7 @@ const Redirection = () => {
       }
     ).then((res) => {
       //요청에 대한 응답 처리 부분
-      const data = res.json();
+      const data = res.json(); //응답을 json 객체로 바꿔줍니다.
       data.then((data) => {
         localStorage.setItem("accessToken", data.access_token); //로컬스토리지에 access token을 저장합니다.
         navigate("/greeting"); //토큰 저장 후 greeting 페이지로 이동합니다.


### PR DESCRIPTION
## 📌 관련 이슈
closed #39 


## ✨ 과제 내용
### 세미나에서 작성한 코드에 주석으로 OAuth 2.0 흐름 설명하기

### 1. Login.jsx
<img width="643" height="399" alt="image" src="https://github.com/user-attachments/assets/91279471-2efc-4e20-b93f-51ddfc466731" />

- **authServerLink** : 카카오 인증 서버에 response_type, client_id, redirect_uri를 쿼리 파라미터로 보낸다.
- **쿼리 파라미터란?** url 뒤에 ?와 함께 키-값 쌍.  &(앰퍼샌드)로 구분해주고 (키)=(값) 형태로 적어준다.
- **handleKakao** : authServerLink로 이동할 수 있도록 하는 함수.  카카오 로그인 버튼에 연결시켜 클릭 시 이동하도록 함.

### 2. Redirection.jsx
<img width="649" height="488" alt="image" src="https://github.com/user-attachments/assets/08ac0177-c2e4-4aa9-b57a-02166dd640b5" />

- **useSearchParams** : 현재 위치의 쿼리 매개변수(쿼리 문자열)에 대한 데이터를 읽고 수정하는데 사용하는 리액트 라우터 돔 라이브러리에서 제공하는 훅.  이것을 이용해서 params에 저장한다. 
- get 메서드에 키 값인 code를 전달하여 해당 키의 value를 authCode에 저장한다.
- 요청에 대한 응답을 json 객체로 변환해주고 로컬 스토리지에 setItem을 사용하여 키("accessToken")와 value(data.access_token)를 저장한다.
- 저장 후 greeting 페이지로 이동.


### 3. Greeting.jsx
<img width="468" height="396" alt="image" src="https://github.com/user-attachments/assets/be735dc4-e252-4dd9-94d7-aa5cb374f474" />

- 이름과 프로필 이미지를 상태값으로 하여 useState로 관리함.
- getItem으로 로컬 스토리지에서 키 값("accessToken")에 해당하는 value(access_token)를 가져옴.
- 가져온 토큰으로 fetch를 이용하여 카카오 사용자 정보 api에서 사용자 정보를 요청.
- 요청에 대한 응답(사용자 정보)을 json 객체로 변환하고 setName과 setProfileImg로 이름과 프로필 이미지를 설정해줌.





## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
### 궁금한 사항
1. 응답을 항상 json 객체로 변환해야하는지?
2. headers 부분을 잘 모르겠음...
